### PR TITLE
Set the default implementation of getType method for ForeignKeyConstraint

### DIFF
--- a/src/main/java/com/healthmarketscience/sqlbuilder/dbspec/ForeignKeyConstraint.java
+++ b/src/main/java/com/healthmarketscience/sqlbuilder/dbspec/ForeignKeyConstraint.java
@@ -32,4 +32,9 @@ public interface ForeignKeyConstraint extends Constraint
 
   /** @return the columns in the referenced table, if not the primary key */
   public List<? extends Column> getReferencedColumns();
+
+  @Override
+  public default Type getType() {
+    return Type.FOREIGN_KEY;
+  }
 }


### PR DESCRIPTION
Set the default implementation of getType method for ForeignKeyConstraint to Type.FORIENG_KEY